### PR TITLE
feat: refresh profile README with rich widgets and platform-skills callout

### DIFF
--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -1,0 +1,24 @@
+name: Generate Snake Animation
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: Platane/snk/svg-only@v3
+        with:
+          github_user_token: ${{ secrets.GITHUB_TOKEN }}
+          outputs: |
+            dist/github-contribution-grid-snake.svg
+            dist/github-contribution-grid-snake-dark.svg?palette=github-dark
+      - uses: crazy-max/ghaction-github-pages@v3
+        with:
+          target_branch: output
+          build_dir: dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,138 +1,87 @@
-# Hi, I'm Nitin Jain 👋  
-### Cloud Architect | Platform Engineer | DevOps Expert | AI Enthusiast | AWS & Azure Certified
+<p align="center">
+  <a href="https://git.io/typing-svg">
+    <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&color=00B4D8&center=true&width=700&lines=Platform+Engineer.+15+years.+Still+shipping.;Kubernetes+%C2%B7+GitOps+%C2%B7+Edge+%C2%B7+AI;I+build+platforms+teams+trust." alt="Typing SVG" />
+  </a>
+</p>
 
-Welcome to my GitHub! I architect and operate cloud platforms that stay fast, secure, automated, and scalable. With **15+ years in IT**, **10+ years in cloud**, **a decade in DevOps**, and a growing passion for **AI-driven automation**, I build systems that run smoothly and inspire others to level up.
-
----
-
-## 🚀 What I Do
-
-- Own and optimize **CDN, DNS, WAF, edge functions (NodeJS), and IIS applications**
-- Architect scalable cloud-native platforms in **AWS and Azure**
-- Design production-ready **Terraform** modules and GitOps workflows
-- Automate everything using **Python, GitHub Actions, Ansible, Bash**
-- Build and integrate workloads across **Kubernetes & EKS**
-- Develop automation and developer-tools enhanced with **AI/LLM workflows**
-- Lead cloud-native transformation from on-prem to edge-first AWS architectures
-- Partner with dev, architecture, and security to bring WAF/CDN/DNS into CI/CD
-- Define and track **metrics, logs, traces** to improve reliability and performance
+<p align="center">
+  I'm Nitin — platform engineer, cloud architect, and open-source builder.<br/>
+  I own CDN, DNS, WAF, and edge functions at scale.<br/>
+  I build platforms on AWS and Azure that keep production boring (in the good way).<br/>
+  15+ years in IT, 10+ years in cloud, and I'm still finding better ways to do it.
+</p>
 
 ---
 
-## 🧠 Core Expertise
+## What I Build
 
-### DevOps, Cloud & Platform Engineering  
-- Kubernetes, EKS, OpenShift  
-- Infrastructure as Code (Terraform)  
-- CI/CD pipelines (GitHub Actions, Jenkins)  
-- GitOps (FluxCD, ArgoCD)  
-- Automation (Python, Bash, Ansible)  
-- Scalability, Reliability & Performance Engineering  
-
-### Cloud Platforms  
-- ☁️ AWS (Primary)
-- ☁️ Azure DevOps & Azure Cloud
-
-### AI & Automation  
-- Building **AI-assisted workflows**, tools, and integrations  
-- Using LLMs to improve developer experience & cloud automation  
-- Experimenting with **AI-driven observability & anomaly detection**  
-
-### Observability & Security  
-- CloudWatch, Prometheus, Grafana  
-- AOSS/OpenSearch, Splunk, Dynatrace  
-- CloudTrail, SecurityHub, AWS Config  
-- WAF, CDN, Route53, IAM  
-
-### Programming  
-- 🐍 Python  
-- 🦫 Go (Golang)  
+| Domain | What I Ship |
+|--------|------------|
+| ☁️ **Edge & CDN** | Global CDN, WAF, DNS, edge functions at org scale |
+| ⚙️ **Platform Engineering** | EKS, OpenShift, Linkerd, KEDA, GitOps with Flux/ArgoCD |
+| 🔒 **Cloud & IAM** | 40+ account AWS Org, OIDC federation, Terraform modules |
+| 🤖 **AI & Observability** | AI-assisted workflows, Dynatrace, anomaly detection, LLM tooling |
 
 ---
 
-## 🛠️ Notable Projects
+## Featured OSS
 
-### 🔹 AWS Organization Setup with Terraform  
-Designed and deployed a 40+ account AWS Org including:
+### [platform-skills](https://github.com/nitinjain999/platform-skills)
 
-- **Billing & Authentication:** Centralized billing, Azure SSO  
-- **Access:** Federated access for AWS, on-prem, GitHub Actions  
-- **Security:** SCPs, permission boundaries, KMS, CloudTrail, SecurityHub  
-- **Networking:** DirectConnect, Transit Gateway, VPN  
-- **Monitoring:** CloudWatch, Grafana, Prometheus, Dynatrace, Splunk  
+A production-grade Claude Code skill for platform engineers. Covers Kubernetes, Terraform, GitOps, KEDA, Linkerd, AWS, and more. Built from real-world patterns, not docs.
 
----
-
-### 🔹 GitHub Organization Overhaul & CI/CD Modernization
-- Managed entire GitHub Org using Terraform  
-- Migrated legacy CI/CD → **GitHub Actions**  
-- Built secure **self-hosted runners** on AWS  
-- Implemented GitHub → AWS OIDC federation  
+[![Stars](https://img.shields.io/github/stars/nitinjain999/platform-skills?style=social)](https://github.com/nitinjain999/platform-skills)
+[![Release](https://img.shields.io/github/v/release/nitinjain999/platform-skills)](https://github.com/nitinjain999/platform-skills/releases)
+[![License](https://img.shields.io/github/license/nitinjain999/platform-skills)](https://github.com/nitinjain999/platform-skills/blob/main/LICENSE)
 
 ---
 
-### 🔹 Platform Ownership & Edge Engineering
-- Managed global CDN, WAF, DNS & edge compute  
-- Optimized caching, routing, and security footprints  
-- Integrated edge services into developer workflows  
+## Tech Stack
+
+<p align="left">
+  <a href="https://skillicons.dev">
+    <img src="https://skillicons.dev/icons?i=kubernetes,aws,azure,terraform,prometheus,grafana,githubactions,python,go&perline=9" />
+  </a>
+</p>
+
+<p align="left">
+  <img src="https://img.shields.io/badge/Linkerd-2563EB?style=flat&logo=linkerd&logoColor=white" />
+  <img src="https://img.shields.io/badge/KEDA-326CE5?style=flat&logoColor=white" />
+  <img src="https://img.shields.io/badge/FluxCD-5468FF?style=flat&logoColor=white" />
+  <img src="https://img.shields.io/badge/ArgoCD-EF7B4D?style=flat&logoColor=white" />
+  <img src="https://img.shields.io/badge/Helm-0F1689?style=flat&logo=helm&logoColor=white" />
+  <img src="https://img.shields.io/badge/Dynatrace-1496FF?style=flat&logo=dynatrace&logoColor=white" />
+  <img src="https://img.shields.io/badge/Splunk-000000?style=flat&logo=splunk&logoColor=white" />
+  <img src="https://img.shields.io/badge/OpenShift-EE0000?style=flat&logo=redhatopenshift&logoColor=white" />
+  <img src="https://img.shields.io/badge/EKS-FF9900?style=flat&logo=amazonaws&logoColor=white" />
+</p>
 
 ---
 
-### 🔹 Edge Lab: 4G Core on Intel NUC
-- Deployed lightweight **4G EPC/UPF core** components  
-- Integrated with AWS VPC for hybrid-cloud experiments  
-- Used for telco DevOps, private LTE, and edge R&D  
+## GitHub Stats
+
+<p align="center">
+  <img src="https://github-readme-stats.vercel.app/api?username=nitinjain999&show_icons=true&theme=tokyonight&hide_border=true&count_private=true" height="165" />
+  <img src="https://streak-stats.demolab.com?user=nitinjain999&theme=tokyonight&hide_border=true" height="165" />
+  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=nitinjain999&layout=compact&theme=tokyonight&hide_border=true" height="165" />
+</p>
+
+<p align="center">
+  <img src="https://github-profile-trophy.vercel.app/?username=nitinjain999&theme=tokyonight&no-frame=true&row=1&column=7" />
+</p>
 
 ---
 
-## 🔧 Technologies & Tools
+## Let's Connect
 
-### OS
-![](https://img.shields.io/badge/-Ubuntu-informational?style=for-the-badge&logo=ubuntu&logoColor=white&color=E95420)
-![](https://img.shields.io/badge/-RedHat_Linux-informational?style=for-the-badge&logo=redhat&logoColor=white&color=EE0000)
-![](https://img.shields.io/badge/-Amazon_Linux-informational?style=for-the-badge&logo=amazonaws&logoColor=white&color=232F3E)
-![](https://img.shields.io/badge/-MacOS-informational?style=for-the-badge&logo=apple&logoColor=white&color=000000)
+Building something platform-shaped? Want to talk Cloud, GitOps, or AI tooling? Let's connect.
 
-### Containers & Orchestration
-![](https://img.shields.io/badge/-RedHat_OpenShift-informational?style=for-the-badge&logo=redhatopenshift&logoColor=white&color=EE0000)
-![](https://img.shields.io/badge/-Docker-informational?style=for-the-badge&logo=docker&logoColor=white&color=2496ED)
-![](https://img.shields.io/badge/-Kubernetes-informational?style=for-the-badge&logo=kubernetes&logoColor=white&color=326CE5)
-![](https://img.shields.io/badge/-Amazon_EKS-informational?style=for-the-badge&logo=amazonaws&logoColor=white&color=232F3E)
-![](https://img.shields.io/badge/-Rancher-informational?style=for-the-badge&logo=rancher&logoColor=white&color=0075A8)
-
-### GitOps & Deployment
-![](https://img.shields.io/badge/-FluxCD-informational?style=for-the-badge&logo=flux&logoColor=white&color=0095D5)
-![](https://img.shields.io/badge/-Argo_CD-informational?style=for-the-badge&logo=argo&logoColor=white&color=EF7B4D)
-![](https://img.shields.io/badge/-Github_Actions-informational?style=for-the-badge&logo=githubactions&logoColor=white&color=2088FF)
-
-### Public Clouds
-![](https://img.shields.io/badge/-AWS-informational?style=for-the-badge&logo=amazonaws&logoColor=white&color=232F3E)
-![](https://img.shields.io/badge/-Azure-informational?style=for-the-badge&logo=microsoftazure&logoColor=white&color=0078D4)
-
-### IaC / Config Management
-![](https://img.shields.io/badge/-Ansible-informational?style=for-the-badge&logo=ansible&logoColor=white&color=EE0000)
-![](https://img.shields.io/badge/-Terraform-informational?style=for-the-badge&logo=terraform&logoColor=white&color=7B42BC)
-
----
-
-## 📊 GitHub Stats
-
-![](https://github-readme-stats.vercel.app/api?username=nitinjain999&theme=blue-green&hide_border=false&include_all_commits=true&count_private=false)
-![](https://github-readme-streak-stats.herokuapp.com/?user=nitinjain999&theme=blue-green&hide_border=false)
-![](https://github-readme-stats.vercel.app/api/top-langs/?username=nitinjain999&theme=blue-green&hide_border=false&layout=compact)
-
----
-
-## 🏆 GitHub Trophies
-![](https://github-profile-trophy.vercel.app/?username=nitinjain999&theme=radical&no-frame=false&no-bg=true&margin-w=4)
-
-<img width="1199" height="328" alt="image" src="https://github.com/user-attachments/assets/056eff7d-c9c7-4840-ab19-510e5625afa6" />
-
----
-
-### ✍️ Dev Quote of the Day
-![](https://quotes-github-readme.vercel.app/api?type=horizontal&theme=radical)
-
----
-
-> Thanks for stopping by! Explore my repos or reach out if you want to talk Cloud, DevOps, Platform Engineering, AI-driven Automation, or Edge Computing.
+<p align="left">
+  <a href="https://github.com/nitinjain999">
+    <img src="https://img.shields.io/github/followers/nitinjain999?label=Follow&style=social" />
+  </a>
+  &nbsp;
+  <a href="mailto:nitin.solna@gmail.com">
+    <img src="https://img.shields.io/badge/Email-nitin.solna%40gmail.com-D14836?style=flat&logo=gmail&logoColor=white" />
+  </a>
+</p>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 <p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=6,11,20&height=200&section=header&text=Nitin%20Jain&fontSize=60&fontColor=fff&animation=twinkling&fontAlignY=35&desc=Platform%20Engineer%20%7C%20Cloud%20Architect%20%7C%20Open-Source%20Builder&descAlignY=55&descSize=18" width="100%" />
+</p>
+
+<p align="center">
   <a href="https://git.io/typing-svg">
-    <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&color=00B4D8&center=true&width=700&lines=Platform+Engineer.+15+years.+Still+shipping.;Kubernetes+%C2%B7+GitOps+%C2%B7+Edge+%C2%B7+AI;I+build+platforms+teams+trust." alt="Typing SVG" />
+    <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=22&pause=1000&color=00B4D8&center=true&vCenter=true&width=750&height=45&lines=Platform+Engineer.+15+years.+Still+shipping.;Kubernetes+%C2%B7+EKS+%C2%B7+OpenShift+%C2%B7+Linkerd+%C2%B7+KEDA;GitOps+with+FluxCD+and+ArgoCD+at+scale;Policy+as+Code+%E2%80%94+OPA+%C2%B7+Kyverno+%C2%B7+Gatekeeper;AI%2FLLM+workflows+%C2%B7+Dynatrace+%C2%B7+Anomaly+Detection;CDN+%C2%B7+WAF+%C2%B7+DNS+%C2%B7+Edge+Functions+at+org+scale;I+build+platforms+teams+trust." alt="Typing SVG" />
   </a>
 </p>
+
+<p align="center">
+  <img src="https://komarev.com/ghpvc/?username=nitinjain999&label=Profile+Views&color=00B4D8&style=flat" alt="profile views" />
+  &nbsp;
+  <a href="https://github.com/nitinjain999?tab=followers">
+    <img src="https://img.shields.io/github/followers/nitinjain999?label=Followers&style=social" />
+  </a>
+</p>
+
+<img src="https://capsule-render.vercel.app/api?type=soft&color=gradient&customColorList=6,11,20&height=3&section=header" width="100%" />
+
+---
 
 <p align="center">
   I'm Nitin — platform engineer, cloud architect, and open-source builder.<br/>
@@ -13,22 +29,23 @@
 
 ---
 
-## What I Build
+## ⚡ What I Build
 
 | Domain | What I Ship |
 |--------|------------|
 | ☁️ **Edge & CDN** | Global CDN, WAF, DNS, edge functions at org scale |
-| ⚙️ **Platform Engineering** | EKS, OpenShift, Linkerd, KEDA, GitOps with Flux/ArgoCD |
+| ⚙️ **Platform Engineering** | EKS, OpenShift, Linkerd, KEDA, GitOps with FluxCD/ArgoCD |
+| 🛡️ **Policy as Code** | OPA, Kyverno, Gatekeeper — guardrails baked into GitOps pipelines |
 | 🔒 **Cloud & IAM** | 40+ account AWS Org, OIDC federation, Terraform modules |
-| 🤖 **AI & Observability** | AI-assisted workflows, Dynatrace, anomaly detection, LLM tooling |
+| 🤖 **AI & Observability** | Claude Code skills, LLM-assisted workflows, Dynatrace, anomaly detection |
 
 ---
 
-## Featured OSS
+## 🚀 Featured OSS
 
 ### [platform-skills](https://github.com/nitinjain999/platform-skills)
 
-A production-grade Claude Code skill for platform engineers. Covers Kubernetes, Terraform, GitOps, KEDA, Linkerd, AWS, and more. Built from real-world patterns, not docs.
+A production-grade Claude Code skill for platform engineers. Covers Kubernetes, Terraform, GitOps, KEDA, Linkerd, OPA, Kyverno, AWS, and more. Built from real-world patterns, not docs.
 
 [![Stars](https://img.shields.io/github/stars/nitinjain999/platform-skills?style=social)](https://github.com/nitinjain999/platform-skills)
 [![Release](https://img.shields.io/github/v/release/nitinjain999/platform-skills)](https://github.com/nitinjain999/platform-skills/releases)
@@ -36,7 +53,7 @@ A production-grade Claude Code skill for platform engineers. Covers Kubernetes, 
 
 ---
 
-## Tech Stack
+## 🧰 Tech Stack
 
 <p align="left">
   <a href="https://skillicons.dev">
@@ -50,15 +67,20 @@ A production-grade Claude Code skill for platform engineers. Covers Kubernetes, 
   <img src="https://img.shields.io/badge/FluxCD-5468FF?style=flat&logoColor=white" />
   <img src="https://img.shields.io/badge/ArgoCD-EF7B4D?style=flat&logoColor=white" />
   <img src="https://img.shields.io/badge/Helm-0F1689?style=flat&logo=helm&logoColor=white" />
+  <img src="https://img.shields.io/badge/OPA-7D3C98?style=flat&logoColor=white" />
+  <img src="https://img.shields.io/badge/Kyverno-326CE5?style=flat&logoColor=white" />
+  <img src="https://img.shields.io/badge/Gatekeeper-FF6B35?style=flat&logoColor=white" />
   <img src="https://img.shields.io/badge/Dynatrace-1496FF?style=flat&logo=dynatrace&logoColor=white" />
   <img src="https://img.shields.io/badge/Splunk-000000?style=flat&logo=splunk&logoColor=white" />
   <img src="https://img.shields.io/badge/OpenShift-EE0000?style=flat&logo=redhatopenshift&logoColor=white" />
   <img src="https://img.shields.io/badge/EKS-FF9900?style=flat&logo=amazonaws&logoColor=white" />
+  <img src="https://img.shields.io/badge/Claude_Code-D97757?style=flat&logoColor=white" />
+  <img src="https://img.shields.io/badge/LLM_Workflows-00B4D8?style=flat&logoColor=white" />
 </p>
 
 ---
 
-## GitHub Stats
+## 📊 GitHub Stats
 
 <p align="center">
   <img src="https://github-readme-stats.vercel.app/api?username=nitinjain999&show_icons=true&theme=tokyonight&hide_border=true&count_private=true" height="165" />
@@ -72,16 +94,30 @@ A production-grade Claude Code skill for platform engineers. Covers Kubernetes, 
 
 ---
 
-## Let's Connect
+## 🐍 Contribution Activity
 
-Building something platform-shaped? Want to talk Cloud, GitOps, or AI tooling? Let's connect.
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/nitinjain999/nitinjain999/output/github-contribution-grid-snake-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/nitinjain999/nitinjain999/output/github-contribution-grid-snake.svg" />
+    <img alt="github-snake" src="https://raw.githubusercontent.com/nitinjain999/nitinjain999/output/github-contribution-grid-snake-dark.svg" />
+  </picture>
+</p>
+
+---
+
+## 🤝 Let's Connect
+
+Building something platform-shaped? Want to talk Cloud, GitOps, Policy as Code, or AI tooling? Let's connect.
 
 <p align="left">
   <a href="https://github.com/nitinjain999">
-    <img src="https://img.shields.io/github/followers/nitinjain999?label=Follow&style=social" />
+    <img src="https://img.shields.io/github/followers/nitinjain999?label=Follow+on+GitHub&style=social" />
   </a>
   &nbsp;
   <a href="mailto:nitin.solna@gmail.com">
     <img src="https://img.shields.io/badge/Email-nitin.solna%40gmail.com-D14836?style=flat&logo=gmail&logoColor=white" />
   </a>
 </p>
+
+<img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=6,11,20&height=100&section=footer" width="100%" />


### PR DESCRIPTION
## Summary

- Animated typing header with rotating taglines
- Domain table (Edge/CDN, Platform Engineering, Cloud/IAM, AI/Observability)
- Featured OSS callout for platform-skills with star/release/license badges
- Tech stack: skillicons.dev icons + shields.io badges for Linkerd, KEDA, Flux, ArgoCD, Helm, Dynatrace, Splunk, OpenShift, EKS
- GitHub Stats, Streak, Top Languages cards (tokyonight theme)
- GitHub Trophies row
- Connect section: GitHub follow button + nitin.solna@gmail.com email badge

## Test plan

- [ ] Preview renders correctly on GitHub profile page (https://github.com/nitinjain999)
- [ ] All badge images load (shields.io, skillicons.dev)
- [ ] readme-typing-svg animation plays on profile page
- [ ] GitHub stats/streak/trophies widgets load (may require a few minutes for cache)
- [ ] platform-skills badges reflect live star/release data
- [ ] Email badge mailto link works
- [ ] GitHub follow button links correctly